### PR TITLE
allow specifying ROCM_VERSION env var to change from default path in CLI

### DIFF
--- a/rocm_techsupport.sh
+++ b/rocm_techsupport.sh
@@ -40,7 +40,7 @@
 #       Check paths for lspci, lshw
 # V1.0: Initial version
 #
-echo "=== ROCm TechSupport Log Collection Utility: V1.25 ==="
+echo "=== ROCm TechSupport Log Collection Utility: V1.26 ==="
 /bin/date
 
 ret=`/bin/grep -i -E 'debian|ubuntu' /etc/os-release`


### PR DESCRIPTION
To allow specifying in CLI an alternate path to ROCm, in case the ROCm install is not in the default /opt/rocm, like this:
```
$ ROCM_VERSION=/usr/local/pkgs-modules/ROCm_4.3/opt/rocm-4.3.0 ./rocm_techsupport.sh
```