### PR TITLE
ROCM_VERSION env variable doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rocm_techsupport.sh V1.28 Shell Utility for Ubuntu/CentOS/SLES/docker log collection from last 3 boots (please enable persistent boot logs.)
+# rocm_techsupport.sh V1.29 Shell Utility for Ubuntu/CentOS/SLES/docker log collection from last 3 boots (please enable persistent boot logs.)
 ### NOTE: To enable persistent boot logs across reboots, please run:  
 ```
   sudo mkdir -p /var/log/journal
@@ -16,6 +16,10 @@ wget -O rocm_techsupport.sh --no-check-certificate https://raw.githubusercontent
 
 #Redirect output to file with SYSTEM_NAME_or_ISSUEID
 sudo sh ./rocm_techsupport.sh > SYSTEM_NAME_or_ISSUEID.rocm_techsupport.log 2>&1
+
+# Use ROCM_VERSION environment variable to specify which installed ROCm to use when
+# collecting logs, for example, ROCM_VERSION=/opt/rocm-5.0.0 to use ROCm 5.0.0 GA version
+sudo ROCM_VERSION=/opt/rocm-5.0.0 sh ./rocm_techsupport.sh > SYSTEM_NAME_or_ISSUE_ID.rocm_techsupport.log 2>&1
 
 # Without sudo, certain data such as verbose lspci, dmidecode may not
 # get captured in the logs


### PR DESCRIPTION
Use ROCM_VERSION=/opt/rocm or ROCM_VERSION=/opt/rocm-5.0.0 to specify installed ROCM path to use when running rocm_techsupport script to collect logs