### PR TITLE
ci: add hourly MI350 docker process monitor (aiswhud-mi350-* runners)

### DIFF
--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -1,0 +1,91 @@
+# Self-Hosted Runner Setup for MI350 Monitor
+
+The `mi350-docker-monitor` workflow requires a GitHub Actions self-hosted runner
+with network access to the AMD internal `.dcgpu` domain.
+
+## 1. Register the Runner
+
+On any Linux host that can reach the `.dcgpu` servers (e.g., an AMD VPN-connected
+jump host, or a server already in the AMD datacenter):
+
+```bash
+# Download the runner from:
+# GitHub → repo → Settings → Actions → Runners → New self-hosted runner
+
+mkdir ~/actions-runner && cd ~/actions-runner
+curl -O -L https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-linux-x64-2.322.0.tar.gz
+tar xzf actions-runner-linux-x64-2.322.0.tar.gz
+
+# Configure — add label 'amd-internal' so the workflow targets it
+./config.sh \
+  --url https://github.com/amddcgpuce/rocmtechsupport \
+  --token <TOKEN_FROM_GITHUB_UI> \
+  --labels amd-internal \
+  --name mi350-monitor-runner
+
+# Install and start as a service
+sudo ./svc.sh install
+sudo ./svc.sh start
+```
+
+## 2. Add GitHub Secrets
+
+In the repo: **Settings → Secrets and variables → Actions**
+
+### `MI350_SSH_KEY`
+The private SSH key used to log into the MI350 servers (must match the public
+key already installed in `~/.ssh/authorized_keys` on each server via Conductor).
+
+```bash
+# Copy the private key content
+cat ~/.ssh/id_rsa   # or id_ed25519, whichever key Conductor uses
+```
+
+Paste the entire output (including `-----BEGIN ... KEY-----` / `-----END ... KEY-----`
+lines) as the secret value.
+
+### `MI350_KNOWN_HOSTS`
+Pre-approved host fingerprints to avoid interactive host-key prompts.
+
+```bash
+# Run this from the jump host / runner host:
+ssh-keyscan \
+  cv350-1e707-c03-2.mkm.dcgpu \
+  smci350-zts-gtu-b14-05.zts-gtu.dcgpu \
+  cv350-zts-gtu-h41-08.zts-gtu.dcgpu \
+  gbt350-odcdh1-b10-1.png-odc.dcgpu \
+  2>/dev/null
+```
+
+Paste the full output as the `MI350_KNOWN_HOSTS` secret value.
+
+## 3. Verify Connectivity
+
+Before the first scheduled run, confirm the runner host can reach all servers:
+
+```bash
+for h in \
+  cv350-1e707-c03-2.mkm.dcgpu \
+  smci350-zts-gtu-b14-05.zts-gtu.dcgpu \
+  cv350-zts-gtu-h41-08.zts-gtu.dcgpu \
+  gbt350-odcdh1-b10-1.png-odc.dcgpu; do
+  ssh -o ConnectTimeout=5 -i ~/.ssh/id_mi350 ssubrama1@${h} hostname && echo "OK: ${h}" || echo "FAIL: ${h}"
+done
+```
+
+## 4. Trigger Manually
+
+After setup, trigger a test run:
+
+```
+GitHub → Actions → MI350 Docker Process Monitor → Run workflow
+```
+
+Optionally pass an extra command (e.g. `docker images`) in the `extra_cmd` input.
+
+## 5. View Results
+
+- **Per-run summary:** Actions tab → select the run → Summary tab
+- **Per-server artifacts:** each run uploads `docker-ps-<label>.txt` files
+  retained for 7 days
+- **History:** all runs listed under the `MI350 Docker Process Monitor` workflow

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -1,91 +1,96 @@
-# Self-Hosted Runner Setup for MI350 Monitor
+# Self-Hosted Runner Setup for MI350 Docker Monitor
 
-The `mi350-docker-monitor` workflow requires a GitHub Actions self-hosted runner
-with network access to the AMD internal `.dcgpu` domain.
+The `mi350-docker-monitor` workflow runs `docker ps` **directly on each MI350
+server** using self-hosted runners installed on the hosts.  No SSH keys or
+VPN tunnels are required.
 
-## 1. Register the Runner
+## Runner Naming Convention
 
-On any Linux host that can reach the `.dcgpu` servers (e.g., an AMD VPN-connected
-jump host, or a server already in the AMD datacenter):
+Runners must be registered with a name that includes the server hostname so
+the workflow matrix can target each one individually.  Expected names:
+
+| Server hostname                          | Runner name                                  |
+|------------------------------------------|----------------------------------------------|
+| cv350-1e707-c03-2.mkm.dcgpu             | `aiswhud-mi350-cv350-1e707-c03-2`           |
+| smci350-zts-gtu-b14-05.zts-gtu.dcgpu   | `aiswhud-mi350-smci350-zts-gtu-b14-05`      |
+| cv350-zts-gtu-h41-08.zts-gtu.dcgpu     | `aiswhud-mi350-cv350-zts-gtu-h41-08`        |
+| gbt350-odcdh1-b10-1.png-odc.dcgpu      | `aiswhud-mi350-gbt350-odcdh1-b10-1`         |
+
+If your actual runner names differ, update the `runner:` fields in
+`.github/workflows/mi350-docker-monitor.yml` → `jobs.probe.strategy.matrix`.
+
+---
+
+## Install the Runner on Each MI350 Server
+
+Run the following on **each** MI350 server (substitute the correct token and
+runner name for that host).
 
 ```bash
-# Download the runner from:
-# GitHub → repo → Settings → Actions → Runners → New self-hosted runner
+# 1. Create a dedicated runner user (optional but recommended)
+sudo useradd -m -s /bin/bash github-runner
+sudo usermod -aG docker github-runner   # allow docker ps without sudo
+sudo su - github-runner
 
+# 2. Download the Actions runner (check https://github.com/actions/runner/releases for latest)
 mkdir ~/actions-runner && cd ~/actions-runner
 curl -O -L https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-linux-x64-2.322.0.tar.gz
 tar xzf actions-runner-linux-x64-2.322.0.tar.gz
 
-# Configure — add label 'amd-internal' so the workflow targets it
+# 3. Register — get TOKEN from:
+#    GitHub → repo → Settings → Actions → Runners → New self-hosted runner
+#    Replace <TOKEN> and <RUNNER-NAME> for each server:
 ./config.sh \
   --url https://github.com/amddcgpuce/rocmtechsupport \
-  --token <TOKEN_FROM_GITHUB_UI> \
-  --labels amd-internal \
-  --name mi350-monitor-runner
+  --token <TOKEN> \
+  --name aiswhud-mi350-cv350-1e707-c03-2 \
+  --labels self-hosted,mi350,aiswhud-mi350-cv350-1e707-c03-2 \
+  --unattended
 
-# Install and start as a service
-sudo ./svc.sh install
+# 4. Install and start as a systemd service
+sudo ./svc.sh install github-runner
 sudo ./svc.sh start
+sudo ./svc.sh status
 ```
 
-## 2. Add GitHub Secrets
+Repeat for each server, changing `--name` and `--labels` to match the table above.
 
-In the repo: **Settings → Secrets and variables → Actions**
+---
 
-### `MI350_SSH_KEY`
-The private SSH key used to log into the MI350 servers (must match the public
-key already installed in `~/.ssh/authorized_keys` on each server via Conductor).
+## Verify Runner Registration
 
-```bash
-# Copy the private key content
-cat ~/.ssh/id_rsa   # or id_ed25519, whichever key Conductor uses
+After installing on all servers, confirm all four appear online:
+
+```
+GitHub → repo → Settings → Actions → Runners
 ```
 
-Paste the entire output (including `-----BEGIN ... KEY-----` / `-----END ... KEY-----`
-lines) as the secret value.
+Each runner should show status **Idle**.
 
-### `MI350_KNOWN_HOSTS`
-Pre-approved host fingerprints to avoid interactive host-key prompts.
+---
 
-```bash
-# Run this from the jump host / runner host:
-ssh-keyscan \
-  cv350-1e707-c03-2.mkm.dcgpu \
-  smci350-zts-gtu-b14-05.zts-gtu.dcgpu \
-  cv350-zts-gtu-h41-08.zts-gtu.dcgpu \
-  gbt350-odcdh1-b10-1.png-odc.dcgpu \
-  2>/dev/null
-```
+## No Secrets Required
 
-Paste the full output as the `MI350_KNOWN_HOSTS` secret value.
+Because each job runs **on** the MI350 server (not SSH-ing into it), the
+workflow needs no `MI350_SSH_KEY` or `MI350_KNOWN_HOSTS` secrets.
+The runner process executes `docker ps` with the permissions of the
+`github-runner` user, which must be in the `docker` group (see step 1 above).
 
-## 3. Verify Connectivity
+---
 
-Before the first scheduled run, confirm the runner host can reach all servers:
-
-```bash
-for h in \
-  cv350-1e707-c03-2.mkm.dcgpu \
-  smci350-zts-gtu-b14-05.zts-gtu.dcgpu \
-  cv350-zts-gtu-h41-08.zts-gtu.dcgpu \
-  gbt350-odcdh1-b10-1.png-odc.dcgpu; do
-  ssh -o ConnectTimeout=5 -i ~/.ssh/id_mi350 ssubrama1@${h} hostname && echo "OK: ${h}" || echo "FAIL: ${h}"
-done
-```
-
-## 4. Trigger Manually
-
-After setup, trigger a test run:
+## Trigger a Manual Test Run
 
 ```
 GitHub → Actions → MI350 Docker Process Monitor → Run workflow
 ```
 
-Optionally pass an extra command (e.g. `docker images`) in the `extra_cmd` input.
+- Leave `extra_cmd` blank for a plain `docker ps`.
+- Or enter e.g. `docker images` to also list pulled images on every server.
 
-## 5. View Results
+## View Results
 
-- **Per-run summary:** Actions tab → select the run → Summary tab
-- **Per-server artifacts:** each run uploads `docker-ps-<label>.txt` files
-  retained for 7 days
-- **History:** all runs listed under the `MI350 Docker Process Monitor` workflow
+| Where | What |
+|-------|------|
+| Actions → run → Summary | Consolidated table + per-server `docker ps` blocks |
+| Actions → run → Artifacts | Per-server `.txt` files (retained 7 days) |
+| Actions → MI350 Docker Process Monitor | Full hourly history |

--- a/.github/workflows/mi350-docker-monitor.yml
+++ b/.github/workflows/mi350-docker-monitor.yml
@@ -1,0 +1,159 @@
+name: MI350 Docker Process Monitor
+
+on:
+  schedule:
+    # Runs every hour at :00
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      extra_cmd:
+        description: 'Optional extra docker command to run (e.g. "docker images")'  
+        required: false
+        default: ''
+
+# Cancel any in-progress run for the same workflow to avoid pile-up
+concurrency:
+  group: mi350-docker-monitor
+  cancel-in-progress: true
+
+jobs:
+  # ── Step 1: probe each server in parallel via matrix ────────────────────────
+  probe:
+    name: "docker ps @ ${{ matrix.host }}"
+    # IMPORTANT: must run on a self-hosted runner that has network access to
+    # the AMD internal .dcgpu domain.  Label the runner 'amd-internal' when
+    # registering it (see README for setup instructions).
+    runs-on: [self-hosted, amd-internal]
+
+    strategy:
+      fail-fast: false          # keep other servers running if one fails
+      matrix:
+        include:
+          - host: cv350-1e707-c03-2.mkm.dcgpu
+            user: ssubrama1
+            label: cv350-mkm
+          - host: smci350-zts-gtu-b14-05.zts-gtu.dcgpu
+            user: ssubrama1
+            label: smci350-zts
+          - host: cv350-zts-gtu-h41-08.zts-gtu.dcgpu
+            user: ssubrama1
+            label: cv350-zts-h41
+          - host: gbt350-odcdh1-b10-1.png-odc.dcgpu
+            user: ssubrama1
+            label: gbt350-odc
+
+    steps:
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.MI350_SSH_KEY }}" > ~/.ssh/id_mi350
+          chmod 600 ~/.ssh/id_mi350
+
+      - name: Add known hosts
+        run: |
+          echo "${{ secrets.MI350_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Collect docker ps from ${{ matrix.host }}
+        id: docker_ps
+        run: |
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+          echo "timestamp=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+
+          OUTPUT=$(ssh -i ~/.ssh/id_mi350 \
+            -o ConnectTimeout=15 \
+            -o StrictHostKeyChecking=yes \
+            -o BatchMode=yes \
+            ${{ matrix.user }}@${{ matrix.host }} \
+            'hostname; echo "---"; docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.Ports}}"' 2>&1)
+          echo "output<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${OUTPUT}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Run extra command (optional)
+        if: ${{ github.event.inputs.extra_cmd != '' }}
+        run: |
+          ssh -i ~/.ssh/id_mi350 \
+            -o ConnectTimeout=15 \
+            -o StrictHostKeyChecking=yes \
+            -o BatchMode=yes \
+            ${{ matrix.user }}@${{ matrix.host }} \
+            '${{ github.event.inputs.extra_cmd }}'
+
+      - name: Write job summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY'
+          ## ${{ matrix.label }} — ${{ steps.docker_ps.outputs.timestamp }}
+
+          ```
+          ${{ steps.docker_ps.outputs.output }}
+          ```
+
+          SUMMARY
+
+      - name: Save output artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-ps-${{ matrix.label }}
+          path: /dev/stdin
+          # Write output to a temp file then upload
+        if: false   # placeholder — see 'collect' job below for real artifact
+
+      - name: Write output file for artifact
+        run: |
+          mkdir -p /tmp/mi350-docker
+          echo "${{ steps.docker_ps.outputs.output }}" \
+            > /tmp/mi350-docker/${{ matrix.label }}.txt
+
+      - name: Upload per-server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-ps-${{ matrix.label }}
+          path: /tmp/mi350-docker/${{ matrix.label }}.txt
+          retention-days: 7
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/id_mi350
+
+  # ── Step 2: merge all artifacts into one summary report ─────────────────────
+  report:
+    name: Consolidated Report
+    runs-on: [self-hosted, amd-internal]
+    needs: probe
+    if: always()
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: docker-ps-*
+          path: /tmp/mi350-report
+          merge-multiple: false
+
+      - name: Build consolidated summary
+        run: |
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+          echo "# MI350 Docker Monitor — ${TIMESTAMP}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Server | Containers Running |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------------------|" >> "$GITHUB_STEP_SUMMARY"
+
+          for f in /tmp/mi350-report/*/; do
+            label=$(basename "${f}" | sed 's/docker-ps-//')
+            count=$(grep -c '^[a-f0-9]\{12\}' "${f}"/*.txt 2>/dev/null || echo 0)
+            echo "| ${label} | ${count} |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Full Output" >> "$GITHUB_STEP_SUMMARY"
+
+          for f in /tmp/mi350-report/*/; do
+            label=$(basename "${f}" | sed 's/docker-ps-//')
+            echo "### ${label}" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat "${f}"/*.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/mi350-docker-monitor.yml
+++ b/.github/workflows/mi350-docker-monitor.yml
@@ -7,104 +7,80 @@ on:
   workflow_dispatch:
     inputs:
       extra_cmd:
-        description: 'Optional extra docker command to run (e.g. "docker images")'  
+        description: 'Extra shell command to run on each server (e.g. "docker images")'
         required: false
         default: ''
 
-# Cancel any in-progress run for the same workflow to avoid pile-up
+# Cancel any in-progress run to avoid pile-up
 concurrency:
   group: mi350-docker-monitor
   cancel-in-progress: true
 
 jobs:
-  # ── Step 1: probe each server in parallel via matrix ────────────────────────
+  # ── Probe each MI350 server in parallel ──────────────────────────────────
   probe:
-    name: "docker ps @ ${{ matrix.host }}"
-    # IMPORTANT: must run on a self-hosted runner that has network access to
-    # the AMD internal .dcgpu domain.  Label the runner 'amd-internal' when
-    # registering it (see README for setup instructions).
-    runs-on: [self-hosted, amd-internal]
+    name: "docker ps @ ${{ matrix.label }}"
 
     strategy:
-      fail-fast: false          # keep other servers running if one fails
+      fail-fast: false   # keep other servers running if one fails
       matrix:
         include:
-          - host: cv350-1e707-c03-2.mkm.dcgpu
-            user: ssubrama1
-            label: cv350-mkm
-          - host: smci350-zts-gtu-b14-05.zts-gtu.dcgpu
-            user: ssubrama1
-            label: smci350-zts
-          - host: cv350-zts-gtu-h41-08.zts-gtu.dcgpu
-            user: ssubrama1
-            label: cv350-zts-h41
-          - host: gbt350-odcdh1-b10-1.png-odc.dcgpu
-            user: ssubrama1
-            label: gbt350-odc
+          # Runner name must match the self-hosted runner registered on each host.
+          # Pattern: aiswhud-mi350-<short-hostname>  (or adjust to actual names below)
+          - label: cv350-mkm
+            runner: aiswhud-mi350-cv350-1e707-c03-2
+          - label: smci350-zts
+            runner: aiswhud-mi350-smci350-zts-gtu-b14-05
+          - label: cv350-zts-h41
+            runner: aiswhud-mi350-cv350-zts-gtu-h41-08
+          - label: gbt350-odc
+            runner: aiswhud-mi350-gbt350-odcdh1-b10-1
+
+    # Each job lands on the specific MI350 server — docker ps runs locally
+    runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Install SSH key
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.MI350_SSH_KEY }}" > ~/.ssh/id_mi350
-          chmod 600 ~/.ssh/id_mi350
-
-      - name: Add known hosts
-        run: |
-          echo "${{ secrets.MI350_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
-
-      - name: Collect docker ps from ${{ matrix.host }}
+      - name: Collect docker ps
         id: docker_ps
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
           echo "timestamp=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
-          OUTPUT=$(ssh -i ~/.ssh/id_mi350 \
-            -o ConnectTimeout=15 \
-            -o StrictHostKeyChecking=yes \
-            -o BatchMode=yes \
-            ${{ matrix.user }}@${{ matrix.host }} \
-            'hostname; echo "---"; docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.Ports}}"' 2>&1)
+          OUTPUT=$(docker ps \
+            --format "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.Ports}}")
           echo "output<<EOF" >> "$GITHUB_OUTPUT"
           echo "${OUTPUT}" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Run extra command (optional)
-        if: ${{ github.event.inputs.extra_cmd != '' }}
-        run: |
-          ssh -i ~/.ssh/id_mi350 \
-            -o ConnectTimeout=15 \
-            -o StrictHostKeyChecking=yes \
-            -o BatchMode=yes \
-            ${{ matrix.user }}@${{ matrix.host }} \
-            '${{ github.event.inputs.extra_cmd }}'
+          # Count running containers (exclude header line)
+          COUNT=$(echo "${OUTPUT}" | tail -n +2 | grep -c . || true)
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
 
-      - name: Write job summary
+      - name: Collect docker images (optional)
+        id: docker_images
+        if: ${{ github.event.inputs.extra_cmd != '' }}
+        run: ${{ github.event.inputs.extra_cmd }}
+
+      - name: Write per-server job summary
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY'
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## ${{ matrix.label }} — ${{ steps.docker_ps.outputs.timestamp }}
 
-          ```
+          **Containers running:** ${{ steps.docker_ps.outputs.count }}
+
+          \`\`\`
           ${{ steps.docker_ps.outputs.output }}
-          ```
+          \`\`\`
 
-          SUMMARY
+          EOF
 
-      - name: Save output artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-ps-${{ matrix.label }}
-          path: /dev/stdin
-          # Write output to a temp file then upload
-        if: false   # placeholder — see 'collect' job below for real artifact
-
-      - name: Write output file for artifact
+      - name: Save output to file for artifact
         run: |
           mkdir -p /tmp/mi350-docker
-          echo "${{ steps.docker_ps.outputs.output }}" \
-            > /tmp/mi350-docker/${{ matrix.label }}.txt
+          {
+            echo "=== ${{ matrix.label }} @ ${{ steps.docker_ps.outputs.timestamp }} ==="
+            echo "${{ steps.docker_ps.outputs.output }}"
+          } > /tmp/mi350-docker/${{ matrix.label }}.txt
 
       - name: Upload per-server artifact
         uses: actions/upload-artifact@v4
@@ -113,14 +89,11 @@ jobs:
           path: /tmp/mi350-docker/${{ matrix.label }}.txt
           retention-days: 7
 
-      - name: Cleanup SSH key
-        if: always()
-        run: rm -f ~/.ssh/id_mi350
-
-  # ── Step 2: merge all artifacts into one summary report ─────────────────────
+  # ── Consolidated summary across all servers ───────────────────────────────
   report:
     name: Consolidated Report
-    runs-on: [self-hosted, amd-internal]
+    # Run the report job on any available MI350 runner
+    runs-on: [self-hosted, mi350]
     needs: probe
     if: always()
 
@@ -135,25 +108,42 @@ jobs:
       - name: Build consolidated summary
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
-          echo "# MI350 Docker Monitor — ${TIMESTAMP}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Server | Containers Running |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|-------------------|" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "# MI350 Docker Monitor — ${TIMESTAMP}"
+            echo ""
+            echo "| Server | Containers Running |"
+            echo "|--------|-------------------|"
 
-          for f in /tmp/mi350-report/*/; do
-            label=$(basename "${f}" | sed 's/docker-ps-//')
-            count=$(grep -c '^[a-f0-9]\{12\}' "${f}"/*.txt 2>/dev/null || echo 0)
-            echo "| ${label} | ${count} |" >> "$GITHUB_STEP_SUMMARY"
-          done
+            for d in /tmp/mi350-report/docker-ps-*/; do
+              label=$(basename "${d}" | sed 's/^docker-ps-//')
+              txt="${d}/${label}.txt"
+              count=0
+              if [[ -f "${txt}" ]]; then
+                # Count non-header, non-separator lines with a container ID
+                count=$(grep -cE '^[a-f0-9]{12}' "${txt}" || true)
+              fi
+              echo "| ${label} | ${count} |"
+            done
 
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "## Full Output" >> "$GITHUB_STEP_SUMMARY"
+            echo ""
+            echo "## Full Output"
+            echo ""
 
-          for f in /tmp/mi350-report/*/; do
-            label=$(basename "${f}" | sed 's/docker-ps-//')
-            echo "### ${label}" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "${f}"/*.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-          done
+            for d in /tmp/mi350-report/docker-ps-*/; do
+              label=$(basename "${d}" | sed 's/^docker-ps-//')
+              txt="${d}/${label}.txt"
+              echo "### ${label}"
+              echo '```'
+              if [[ -f "${txt}" ]]; then
+                cat "${txt}"
+              else
+                echo "(no output)"
+              fi
+              echo '```'
+              echo ""
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup temp files
+        if: always()
+        run: rm -rf /tmp/mi350-report /tmp/mi350-docker


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs every hour to collect `docker ps` output from all four MI350 servers, using self-hosted runners installed directly on each host.

- No SSH keys or secrets required — each job runs **on** the MI350 server via its local runner
- 4-way parallel matrix (one job per server, `fail-fast: false`)
- Manual `workflow_dispatch` trigger with optional extra command input (e.g. `docker images`)
- Per-run GitHub Actions job summary with container count table + full output
- Per-server `.txt` artifacts retained 7 days

## Files Added

| File | Purpose |
|------|---------|
| `.github/workflows/mi350-docker-monitor.yml` | Hourly workflow — matrix over 4 MI350 runners |
| `.github/RUNNER_SETUP.md` | How to register `aiswhud-mi350-*` runners on each server |

## Runner Naming

Each runner must be registered on its host with a name matching:

| Server | Runner name |
|--------|-------------|
| cv350-1e707-c03-2.mkm.dcgpu | `aiswhud-mi350-cv350-1e707-c03-2` |
| smci350-zts-gtu-b14-05.zts-gtu.dcgpu | `aiswhud-mi350-smci350-zts-gtu-b14-05` |
| cv350-zts-gtu-h41-08.zts-gtu.dcgpu | `aiswhud-mi350-cv350-zts-gtu-h41-08` |
| gbt350-odcdh1-b10-1.png-odc.dcgpu | `aiswhud-mi350-gbt350-odcdh1-b10-1` |

If runner names differ, update the `runner:` fields in the matrix before merging.

## Test Plan

- [ ] Verify all 4 runners appear **Idle** in repo Settings → Actions → Runners
- [ ] Trigger manual run and confirm 4 parallel jobs complete
- [ ] Check job summary shows container counts and `docker ps` tables
- [ ] Confirm artifacts upload correctly
- [ ] Let one scheduled run fire and verify hourly cron works
